### PR TITLE
Fix windows

### DIFF
--- a/src/windows.rs
+++ b/src/windows.rs
@@ -1,12 +1,16 @@
 use std::ops;
 use std::os::windows::io::{AsRawHandle, RawHandle};
-use winapi::um::fileapi::{LockFile, LockFileEx, UnlockFile, LOCKFILE_EXCLUSIVE_LOCK};
+use std::io::{Error, ErrorKind};
+use std::os::windows::raw::HANDLE;
+
+use winapi::um::fileapi::{LockFile, LockFileEx, UnlockFile};
+use winapi::um::minwinbase::LOCKFILE_EXCLUSIVE_LOCK;
 
 /// Lock a file descriptor.
 #[inline]
-pub fn lock(handle: RawHandle) -> Result<LockGuard, Error> {
+pub fn lock(handle: RawHandle) -> Result<FdLockGuard<'_>, Error> {
     if unsafe { LockFile(handle, 0, 0, 1, 0) } {
-        Ok(LockGuard { handle })
+        Ok(FdLockGuard { handle })
     } else {
         Err(ErrorKind::Locked.into())
     }

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -1,6 +1,6 @@
-use std::ops;
-use std::os::windows::io::{AsRawHandle};
 use std::io::{Error, ErrorKind};
+use std::ops;
+use std::os::windows::io::AsRawHandle;
 
 use winapi::um::fileapi::{LockFile, UnlockFile};
 
@@ -77,7 +77,7 @@ impl<T: AsRawHandle> FdLock<T> {
     // #[inline]
     // pub fn lock(&mut self) -> Result<FdLockGuard<'_, T>, Error> {
     //     let handle = self.t.as_raw_handle();
-    //     let overlapped = ptr::null_mut()  
+    //     let overlapped = ptr::null_mut()
     //     if unsafe { LockFile(handle, 0, 0, 1, 0) } {
     //         Ok(FdLockGuard { lock: self })
     //     } else {


### PR DESCRIPTION
Fixes the Windows code, resolving #2. The only downside of this patch is that I had to disable the `lock` function because I'm unsure how to initialize the OVERLAPPED struct (something I still need to learn, heh).

Either way, this should be better now. Thanks!