### PR TITLE
Reduce dependencies on non-windows targets

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,10 @@ edition = "2018"
 
 [dependencies]
 libc = "0.2.58"
-winapi = "0.3.7"
 failure = "0.1.5"
+
+[target.'cfg(windows)'.dependencies]
+winapi = "0.3.7"
 
 [dev-dependencies]
 tempfile = "3.0.8"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Depend on `winapi` crate only on `windows` target.

## Motivation and Context
`winapi` is only required on `windows` target, but it is currently fetched even for "unix" platforms. With this PR merged, the amount of downloaded data is reduced significantly on non-windows targets.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
