### PR TITLE
Remove dependency on failure

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,6 @@ edition = "2018"
 [dependencies]
 libc = "0.2.58"
 winapi = "0.3.7"
-failure = "0.1.5"
 
 [dev-dependencies]
 tempfile = "3.0.8"

--- a/README.md
+++ b/README.md
@@ -22,14 +22,19 @@ use fd_lock::FdLock;
 use tempfile::tempfile;
 use std::io::prelude::*;
 use std::fs::File;
+use std::error::Error;
 
-fn main() -> Result<(), failure::Error> {
+fn main() -> Result<(), Box<dyn Error>> {
     // Lock a file and write to it.
     let mut f = FdLock::new(tempfile()?);
-    f.try_lock()?.write_all(b"chashu cat")?;
+    f.lock()?.write_all(b"chashu cat")?;
+
+    // Non-blocking flavour
+    f.try_lock()?.write_all(b"yay")?;
 
     // Locks can also be held for extended durations.
-    let mut f = f.try_lock()?;
+    let mut f = f.lock()?;
+
     f.write_all(b"nori cat")?;
     f.write_all(b"bird!")?;
     Ok(())

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,4 +1,3 @@
-use failure::{self, Backtrace, Context, Fail};
 use std::fmt;
 
 /// Error categories.
@@ -9,56 +8,48 @@ use std::fmt;
 /// This list is non-exhaustive.
 ///
 /// [`Error`]: std.struct.Error.html
-#[derive(Debug, Fail)]
+#[derive(Debug)]
+#[non_exhaustive]
 pub enum ErrorKind {
     /// The lock is already held.
-    #[fail(display = "The fd is locked")]
     Locked,
     /// Any error not part of this list.
-    #[fail(display = "Generic error.")]
     Other,
+}
+
+impl fmt::Display for ErrorKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let message = match self {
+            ErrorKind::Locked => "The fd is locked",
+            ErrorKind::Other => "Generic error",
+        };
+        f.write_str(message)
+    }
 }
 
 /// A specialized `Error` type.
 #[derive(Debug)]
-pub struct Error {
-    inner: Context<ErrorKind>,
-}
+pub struct Error(ErrorKind);
 
 impl Error {
     /// Access the [`ErrorKind`] member.
     ///
     /// [`ErrorKind`]: enum.ErrorKind.html
     pub fn kind(&self) -> &ErrorKind {
-        &*self.inner.get_context()
+        &self.0
     }
 }
 
-impl Fail for Error {
-    fn cause(&self) -> Option<&dyn Fail> {
-        self.inner.cause()
-    }
-
-    fn backtrace(&self) -> Option<&Backtrace> {
-        self.inner.backtrace()
-    }
-}
+impl std::error::Error for Error {}
 
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt::Display::fmt(&self.inner, f)
+        fmt::Display::fmt(&self.0, f)
     }
 }
 
 impl From<ErrorKind> for Error {
     fn from(kind: ErrorKind) -> Error {
-        let inner = Context::new(kind);
-        Error { inner }
-    }
-}
-
-impl From<Context<ErrorKind>> for Error {
-    fn from(inner: Context<ErrorKind>) -> Error {
-        Error { inner }
+        Error(kind)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,14 +10,18 @@
 //! # use tempfile::tempfile;
 //! # use std::io::prelude::*;
 //! # use std::fs::File;
+//! # use std::error::Error;
 //!
-//! # fn main() -> Result<(), failure::Error> {
+//! # fn main() -> Result<(), Box<dyn Error>> {
 //! // Lock a file and write to it.
 //! let mut f = FdLock::new(tempfile()?);
-//! f.try_lock()?.write_all(b"chashu cat")?;
+//! f.lock()?.write_all(b"chashu cat")?;
+//!
+//! // Non-blocking flavour
+//! f.try_lock()?.write_all(b"yay")?;
 //!
 //! // Locks can also be held for extended durations.
-//! let mut f = f.try_lock()?;
+//! let mut f = f.lock()?;
 //! f.write_all(b"nori cat")?;
 //! f.write_all(b"bird!")?;
 //! # Ok(())}


### PR DESCRIPTION
## Description
The crate no longer depends on failure.
The error now implements `std::error::Error`.
Note that this is a **BREAKING CHANGE**, because `failure::Context` was leaked to the public API (via `From<Context<ErrorKind>>` impl.
Whilst this introduces a breaking change (which essentially means moving to `v2.0.0`) I suggest making distinct error types for `lock()` and `try_lock()` functions as it is done for [`std::sync::Mutex::lock`](https://doc.rust-lang.org/stable/std/sync/struct.Mutex.html#method.lock) and [`std::sync::Mutex::try_lock`](https://doc.rust-lang.org/stable/std/sync/struct.Mutex.html#method.try_lock), besides that it would be nice to have an ability to handle unlock error, this would just mean having a consuming `unlock(self)` method which returns a `Result`.

@yoshuawuyts I see this repo hasn't seen enough activity lately, but this is the crate people see one of the first when googling for file locks in Rust. If you feel you don't have enough time/motivation for maintaining it I suggest my help with that.

## Motivation and Context
Closes #4 

## Types of changes
- [x] Breaking change (fix or feature that would cause existing functionality to change)
