### PR TITLE
Determine cause of failure from errno

### DIFF
--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,6 +1,21 @@
-use std::error::Error;
+use fd_lock::{ErrorKind, FdLock};
+
+use std::fs::File;
+
+use tempfile::tempdir;
 
 #[test]
-fn should_work() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
-    Ok(())
+fn double_lock() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("lockfile");
+
+    let mut l0 = FdLock::new(File::create(&path).unwrap());
+    let mut l1 = FdLock::new(File::open(path).unwrap());
+
+    let g0 = l0.lock().unwrap();
+
+    let err = l1.try_lock().unwrap_err();
+    assert!(matches!(err.kind(), ErrorKind::Locked));
+
+    drop(g0);
 }


### PR DESCRIPTION
## Description

Closes #8 by checking errno (via `std::io::Error::last_os_error()`) instead of checking the return value of `flock` directly.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
