### PR TITLE
Use the new I/O safety traits, using rustix

### DIFF
--- a/src/read_guard.rs
+++ b/src/read_guard.rs
@@ -13,17 +13,17 @@ use crate::sys;
 /// [`RwLock`]: crate::RwLock
 #[must_use = "if unused the RwLock will immediately unlock"]
 #[derive(Debug)]
-pub struct RwLockReadGuard<'lock, T: sys::AsRaw> {
+pub struct RwLockReadGuard<'lock, T: sys::AsOpenFile> {
     guard: sys::RwLockReadGuard<'lock, T>,
 }
 
-impl<'lock, T: sys::AsRaw> RwLockReadGuard<'lock, T> {
+impl<'lock, T: sys::AsOpenFile> RwLockReadGuard<'lock, T> {
     pub(crate) fn new(guard: sys::RwLockReadGuard<'lock, T>) -> Self {
         Self { guard }
     }
 }
 
-impl<T: sys::AsRaw> ops::Deref for RwLockReadGuard<'_, T> {
+impl<T: sys::AsOpenFile> ops::Deref for RwLockReadGuard<'_, T> {
     type Target = T;
 
     #[inline]
@@ -33,7 +33,7 @@ impl<T: sys::AsRaw> ops::Deref for RwLockReadGuard<'_, T> {
 }
 
 /// Release the lock.
-impl<T: sys::AsRaw> Drop for RwLockReadGuard<'_, T> {
+impl<T: sys::AsOpenFile> Drop for RwLockReadGuard<'_, T> {
     #[inline]
     fn drop(&mut self) {}
 }

--- a/src/rw_lock.rs
+++ b/src/rw_lock.rs
@@ -10,11 +10,11 @@ use std::io;
 /// underlying data (exclusive access) and the read portion of this lock typically
 /// allows for read-only access (shared access).
 #[derive(Debug)]
-pub struct RwLock<T: sys::AsRaw> {
+pub struct RwLock<T: sys::AsOpenFile> {
     lock: sys::RwLock<T>,
 }
 
-impl<T: sys::AsRaw> RwLock<T> {
+impl<T: sys::AsOpenFile> RwLock<T> {
     /// Create a new instance.
     ///
     /// # Examples

--- a/src/sys/mod.rs
+++ b/src/sys/mod.rs
@@ -4,12 +4,12 @@ cfg_if! {
     if #[cfg(unix)] {
         mod unix;
         pub use unix::*;
-        pub(crate) use std::os::unix::prelude::AsRawFd as AsRaw;
+        pub(crate) use rustix::fd::AsFd as AsOpenFile;
     } else if #[cfg(windows)] {
         mod windows;
         pub use windows::*;
         #[doc(no_inline)]
-        pub(crate) use std::os::windows::prelude::AsRawHandle as AsRaw;
+        pub(crate) use std::os::windows::io::AsHandle as AsOpenFile;
     } else {
         mod unsupported;
         pub use unsupported;

--- a/src/sys/unix/read_guard.rs
+++ b/src/sys/unix/read_guard.rs
@@ -1,21 +1,21 @@
+use rustix::fd::AsFd;
 use rustix::fs::{flock, FlockOperation};
 use std::ops;
-use std::os::unix::io::AsRawFd;
 
 use super::RwLock;
 
 #[derive(Debug)]
-pub struct RwLockReadGuard<'lock, T: AsRawFd> {
+pub struct RwLockReadGuard<'lock, T: AsFd> {
     lock: &'lock RwLock<T>,
 }
 
-impl<'lock, T: AsRawFd> RwLockReadGuard<'lock, T> {
+impl<'lock, T: AsFd> RwLockReadGuard<'lock, T> {
     pub(crate) fn new(lock: &'lock RwLock<T>) -> Self {
         Self { lock }
     }
 }
 
-impl<T: AsRawFd> ops::Deref for RwLockReadGuard<'_, T> {
+impl<T: AsFd> ops::Deref for RwLockReadGuard<'_, T> {
     type Target = T;
 
     #[inline]
@@ -24,9 +24,9 @@ impl<T: AsRawFd> ops::Deref for RwLockReadGuard<'_, T> {
     }
 }
 
-impl<T: AsRawFd> Drop for RwLockReadGuard<'_, T> {
+impl<T: AsFd> Drop for RwLockReadGuard<'_, T> {
     #[inline]
     fn drop(&mut self) {
-        let _ = flock(&self.lock.as_fd(), FlockOperation::Unlock).ok();
+        let _ = flock(&self.lock.inner.as_fd(), FlockOperation::Unlock).ok();
     }
 }

--- a/src/sys/unix/rw_lock.rs
+++ b/src/sys/unix/rw_lock.rs
@@ -1,16 +1,15 @@
-use rustix::fd::BorrowedFd;
+use rustix::fd::AsFd;
 use rustix::fs::{flock, FlockOperation};
 use std::io::{self, Error, ErrorKind};
-use std::os::unix::io::AsRawFd;
 
 use super::{RwLockReadGuard, RwLockWriteGuard};
 
 #[derive(Debug)]
-pub struct RwLock<T: AsRawFd> {
+pub struct RwLock<T: AsFd> {
     pub(crate) inner: T,
 }
 
-impl<T: AsRawFd> RwLock<T> {
+impl<T: AsFd> RwLock<T> {
     #[inline]
     pub fn new(inner: T) -> Self {
         RwLock { inner }
@@ -18,15 +17,17 @@ impl<T: AsRawFd> RwLock<T> {
 
     #[inline]
     pub fn write(&mut self) -> io::Result<RwLockWriteGuard<'_, T>> {
-        flock(&self.as_fd(), FlockOperation::LockExclusive)?;
+        flock(&self.inner.as_fd(), FlockOperation::LockExclusive)?;
         Ok(RwLockWriteGuard::new(self))
     }
 
     #[inline]
     pub fn try_write(&mut self) -> Result<RwLockWriteGuard<'_, T>, Error> {
-        flock(&self.as_fd(), FlockOperation::NonBlockingLockExclusive).map_err(|err| match err
-            .kind()
-        {
+        flock(
+            &self.inner.as_fd(),
+            FlockOperation::NonBlockingLockExclusive,
+        )
+        .map_err(|err| match err.kind() {
             ErrorKind::AlreadyExists => ErrorKind::WouldBlock.into(),
             _ => Error::from(err),
         })?;
@@ -35,18 +36,18 @@ impl<T: AsRawFd> RwLock<T> {
 
     #[inline]
     pub fn read(&self) -> io::Result<RwLockReadGuard<'_, T>> {
-        flock(&self.as_fd(), FlockOperation::LockShared)?;
+        flock(&self.inner.as_fd(), FlockOperation::LockShared)?;
         Ok(RwLockReadGuard::new(self))
     }
 
     #[inline]
     pub fn try_read(&self) -> Result<RwLockReadGuard<'_, T>, Error> {
-        flock(&self.as_fd(), FlockOperation::NonBlockingLockShared).map_err(|err| {
-            match err.kind() {
+        flock(&self.inner.as_fd(), FlockOperation::NonBlockingLockShared).map_err(
+            |err| match err.kind() {
                 ErrorKind::AlreadyExists => ErrorKind::WouldBlock.into(),
                 _ => Error::from(err),
-            }
-        })?;
+            },
+        )?;
         Ok(RwLockReadGuard::new(self))
     }
 
@@ -56,15 +57,5 @@ impl<T: AsRawFd> RwLock<T> {
         T: Sized,
     {
         self.inner
-    }
-
-    #[inline]
-    pub(crate) fn as_fd(&self) -> BorrowedFd<'_> {
-        // Safety: We assume that `self.inner`'s file descriptor is valid for
-        // at least the lifetime of `self`.
-        //
-        // Once I/O safety is stablized in std, we can switch the public API to
-        // use `AsFd` instead of `AsRawFd` and eliminate this `unsafe` block.
-        unsafe { BorrowedFd::borrow_raw(self.inner.as_raw_fd()) }
     }
 }

--- a/src/sys/unix/write_guard.rs
+++ b/src/sys/unix/write_guard.rs
@@ -1,21 +1,21 @@
+use rustix::fd::AsFd;
 use rustix::fs::{flock, FlockOperation};
 use std::ops;
-use std::os::unix::io::AsRawFd;
 
 use super::RwLock;
 
 #[derive(Debug)]
-pub struct RwLockWriteGuard<'lock, T: AsRawFd> {
+pub struct RwLockWriteGuard<'lock, T: AsFd> {
     lock: &'lock mut RwLock<T>,
 }
 
-impl<'lock, T: AsRawFd> RwLockWriteGuard<'lock, T> {
+impl<'lock, T: AsFd> RwLockWriteGuard<'lock, T> {
     pub(crate) fn new(lock: &'lock mut RwLock<T>) -> Self {
         Self { lock }
     }
 }
 
-impl<T: AsRawFd> ops::Deref for RwLockWriteGuard<'_, T> {
+impl<T: AsFd> ops::Deref for RwLockWriteGuard<'_, T> {
     type Target = T;
 
     #[inline]
@@ -24,16 +24,16 @@ impl<T: AsRawFd> ops::Deref for RwLockWriteGuard<'_, T> {
     }
 }
 
-impl<T: AsRawFd> ops::DerefMut for RwLockWriteGuard<'_, T> {
+impl<T: AsFd> ops::DerefMut for RwLockWriteGuard<'_, T> {
     #[inline]
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.lock.inner
     }
 }
 
-impl<T: AsRawFd> Drop for RwLockWriteGuard<'_, T> {
+impl<T: AsFd> Drop for RwLockWriteGuard<'_, T> {
     #[inline]
     fn drop(&mut self) {
-        let _ = flock(&self.lock.as_fd(), FlockOperation::Unlock).ok();
+        let _ = flock(&self.lock.inner.as_fd(), FlockOperation::Unlock).ok();
     }
 }

--- a/src/sys/windows/read_guard.rs
+++ b/src/sys/windows/read_guard.rs
@@ -1,3 +1,4 @@
+use std::os::windows::io::AsHandle;
 use windows_sys::Win32::Foundation::HANDLE;
 use windows_sys::Win32::Storage::FileSystem::UnlockFile;
 
@@ -8,11 +9,11 @@ use super::utils::syscall;
 use super::RwLock;
 
 #[derive(Debug)]
-pub struct RwLockReadGuard<'lock, T: AsRawHandle> {
+pub struct RwLockReadGuard<'lock, T: AsHandle> {
     pub(crate) lock: &'lock RwLock<T>,
 }
 
-impl<T: AsRawHandle> ops::Deref for RwLockReadGuard<'_, T> {
+impl<T: AsHandle> ops::Deref for RwLockReadGuard<'_, T> {
     type Target = T;
 
     #[inline]
@@ -21,10 +22,10 @@ impl<T: AsRawHandle> ops::Deref for RwLockReadGuard<'_, T> {
     }
 }
 
-impl<T: AsRawHandle> Drop for RwLockReadGuard<'_, T> {
+impl<T: AsHandle> Drop for RwLockReadGuard<'_, T> {
     #[inline]
     fn drop(&mut self) {
-        let handle = self.lock.inner.as_raw_handle() as HANDLE;
+        let handle = self.lock.inner.as_handle().as_raw_handle() as HANDLE;
         let _ = syscall(unsafe { UnlockFile(handle, 0, 0, 1, 0) });
     }
 }

--- a/src/sys/windows/write_guard.rs
+++ b/src/sys/windows/write_guard.rs
@@ -1,3 +1,4 @@
+use std::os::windows::io::AsHandle;
 use windows_sys::Win32::Foundation::HANDLE;
 use windows_sys::Win32::Storage::FileSystem::UnlockFile;
 
@@ -8,11 +9,11 @@ use super::utils::syscall;
 use super::RwLock;
 
 #[derive(Debug)]
-pub struct RwLockWriteGuard<'lock, T: AsRawHandle> {
+pub struct RwLockWriteGuard<'lock, T: AsHandle> {
     pub(crate) lock: &'lock mut RwLock<T>,
 }
 
-impl<T: AsRawHandle> ops::Deref for RwLockWriteGuard<'_, T> {
+impl<T: AsHandle> ops::Deref for RwLockWriteGuard<'_, T> {
     type Target = T;
 
     #[inline]
@@ -21,17 +22,17 @@ impl<T: AsRawHandle> ops::Deref for RwLockWriteGuard<'_, T> {
     }
 }
 
-impl<T: AsRawHandle> ops::DerefMut for RwLockWriteGuard<'_, T> {
+impl<T: AsHandle> ops::DerefMut for RwLockWriteGuard<'_, T> {
     #[inline]
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.lock.inner
     }
 }
 
-impl<T: AsRawHandle> Drop for RwLockWriteGuard<'_, T> {
+impl<T: AsHandle> Drop for RwLockWriteGuard<'_, T> {
     #[inline]
     fn drop(&mut self) {
-        let handle = self.lock.inner.as_raw_handle() as HANDLE;
+        let handle = self.lock.inner.as_handle().as_raw_handle() as HANDLE;
         let _ = syscall(unsafe { UnlockFile(handle, 0, 0, 1, 0) });
     }
 }

--- a/src/write_guard.rs
+++ b/src/write_guard.rs
@@ -13,17 +13,17 @@ use crate::sys;
 /// [`RwLock`]: crate::RwLock
 #[must_use = "if unused the RwLock will immediately unlock"]
 #[derive(Debug)]
-pub struct RwLockWriteGuard<'lock, T: sys::AsRaw> {
+pub struct RwLockWriteGuard<'lock, T: sys::AsOpenFile> {
     guard: sys::RwLockWriteGuard<'lock, T>,
 }
 
-impl<'lock, T: sys::AsRaw> RwLockWriteGuard<'lock, T> {
+impl<'lock, T: sys::AsOpenFile> RwLockWriteGuard<'lock, T> {
     pub(crate) fn new(guard: sys::RwLockWriteGuard<'lock, T>) -> Self {
         Self { guard }
     }
 }
 
-impl<T: sys::AsRaw> ops::Deref for RwLockWriteGuard<'_, T> {
+impl<T: sys::AsOpenFile> ops::Deref for RwLockWriteGuard<'_, T> {
     type Target = T;
 
     #[inline]
@@ -32,7 +32,7 @@ impl<T: sys::AsRaw> ops::Deref for RwLockWriteGuard<'_, T> {
     }
 }
 
-impl<T: sys::AsRaw> ops::DerefMut for RwLockWriteGuard<'_, T> {
+impl<T: sys::AsOpenFile> ops::DerefMut for RwLockWriteGuard<'_, T> {
     #[inline]
     fn deref_mut(&mut self) -> &mut Self::Target {
         self.guard.deref_mut()
@@ -40,7 +40,7 @@ impl<T: sys::AsRaw> ops::DerefMut for RwLockWriteGuard<'_, T> {
 }
 
 /// Release the lock.
-impl<T: sys::AsRaw> Drop for RwLockWriteGuard<'_, T> {
+impl<T: sys::AsOpenFile> Drop for RwLockWriteGuard<'_, T> {
     #[inline]
     fn drop(&mut self) {}
 }


### PR DESCRIPTION
This implements the idea in https://github.com/yoshuawuyts/fd-lock/issues/12.

Switch public APIs from `AsRawFd`/`AsRawHandle` to the new I/O safety
traits `AsFd`/`AsHandle`. On Unix platforms, use `rustix` to avoid
manipulating raw file descriptors altogether.

This uses `AsFd` and `AsHandle` from the `io-lifetimes` crate, which are
identical to traits which will hopefully be landing in libstd soon.