### PR TITLE
Migrate to `windows-sys`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,8 +15,13 @@ edition = "2018"
 libc = "0.2.58"
 cfg-if = "1.0.0"
 
-[target.'cfg(windows)'.dependencies]
-winapi = "0.3.7"
+[target.'cfg(windows)'.dependencies.windows-sys]
+version = "0.28.0"
+features = [
+    "Win32_Foundation",
+    "Win32_Storage_FileSystem",
+    "Win32_System_IO",
+]
 
 [dev-dependencies]
 tempfile = "3.0.8"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,7 +30,7 @@
 
 #![forbid(future_incompatible)]
 #![deny(missing_debug_implementations, nonstandard_style)]
-#![warn(missing_docs, missing_doc_code_examples)]
+#![warn(missing_docs, rustdoc::missing_doc_code_examples)]
 
 mod read_guard;
 mod rw_lock;

--- a/src/sys/windows/read_guard.rs
+++ b/src/sys/windows/read_guard.rs
@@ -1,4 +1,4 @@
-use winapi::um::fileapi::UnlockFile;
+use windows_sys::Win32::Storage::FileSystem::UnlockFile;
 
 use std::ops;
 use std::os::windows::prelude::*;

--- a/src/sys/windows/rw_lock.rs
+++ b/src/sys/windows/rw_lock.rs
@@ -1,8 +1,9 @@
 use std::io::{self, Error, ErrorKind};
 use std::os::windows::io::AsRawHandle;
 
-use winapi::um::fileapi::LockFileEx;
-use winapi::um::minwinbase::{LOCKFILE_EXCLUSIVE_LOCK, LOCKFILE_FAIL_IMMEDIATELY};
+use windows_sys::Win32::Storage::FileSystem::{
+    LockFileEx, LOCKFILE_EXCLUSIVE_LOCK, LOCKFILE_FAIL_IMMEDIATELY,
+};
 
 use super::utils::{syscall, Overlapped};
 use super::{RwLockReadGuard, RwLockWriteGuard};

--- a/src/sys/windows/utils.rs
+++ b/src/sys/windows/utils.rs
@@ -1,8 +1,8 @@
 use std::io;
 use std::mem;
 
-use winapi::shared::minwindef::BOOL;
-use winapi::um::minwinbase::OVERLAPPED;
+use windows_sys::Win32::Foundation::BOOL;
+use windows_sys::Win32::System::IO::OVERLAPPED;
 
 /// A wrapper around `OVERLAPPED` to provide "rustic" accessors and
 /// initializers.

--- a/src/sys/windows/write_guard.rs
+++ b/src/sys/windows/write_guard.rs
@@ -1,4 +1,4 @@
-use winapi::um::fileapi::UnlockFile;
+use windows_sys::Win32::Storage::FileSystem::UnlockFile;
 
 use std::ops;
 use std::os::windows::prelude::*;


### PR DESCRIPTION
This moves us from `winapi` to `windows-sys` crate for our dependencies. Thanks!