### PR TITLE
Use rustix instead of calling libc directly.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,6 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-libc = "0.2.58"
 cfg-if = "1.0.0"
 
 [target.'cfg(windows)'.dependencies.windows-sys]
@@ -22,6 +21,9 @@ features = [
     "Win32_Storage_FileSystem",
     "Win32_System_IO",
 ]
+
+[target.'cfg(unix)'.dependencies]
+rustix = "0.32.0"
 
 [dev-dependencies]
 tempfile = "3.0.8"

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ $ cargo add fd-lock
 ```
 
 ## Safety
-This crate uses `unsafe` to interface with `libc` and `windows-sys`. All
+This crate uses `unsafe` on Windows to interface with `windows-sys`. All
 invariants have been carefully checked, and are manually enforced.
 
 ## Contributing
@@ -50,8 +50,8 @@ look at some of these issues:
 
 ## References
 - [LockFile function - WDC](https://docs.microsoft.com/en-us/windows/desktop/api/fileapi/nf-fileapi-lockfile)
-- [flock(2) - Linux Man Page](https://linux.die.net/man/2/flock)
-- [`libc::flock`](https://docs.rs/libc/0.2.58/libc/fn.flock.html)
+- [flock(2) - Linux Man Page](https://man7.org/linux/man-pages/man2/flock.2.html)
+- [`rustix::fs::flock`](https://docs.rs/rustix/*/rustix/fs/fn.flock.html)
 - [`windows_sys::Win32::Storage::FileSystem::LockFile`](https://microsoft.github.io/windows-docs-rs/doc/windows/Win32/Storage/FileSystem/fn.LockFile.html)
 
 ## License

--- a/src/sys/unix/mod.rs
+++ b/src/sys/unix/mod.rs
@@ -2,8 +2,6 @@ mod read_guard;
 mod rw_lock;
 mod write_guard;
 
-pub(crate) mod utils;
-
 pub use read_guard::RwLockReadGuard;
 pub use rw_lock::RwLock;
 pub use write_guard::RwLockWriteGuard;

--- a/src/sys/unix/read_guard.rs
+++ b/src/sys/unix/read_guard.rs
@@ -1,8 +1,7 @@
-use libc::{flock, LOCK_UN};
+use rustix::fs::{flock, FlockOperation};
 use std::ops;
 use std::os::unix::io::AsRawFd;
 
-use super::utils::syscall;
 use super::RwLock;
 
 #[derive(Debug)]
@@ -28,7 +27,6 @@ impl<T: AsRawFd> ops::Deref for RwLockReadGuard<'_, T> {
 impl<T: AsRawFd> Drop for RwLockReadGuard<'_, T> {
     #[inline]
     fn drop(&mut self) {
-        let fd = self.lock.inner.as_raw_fd();
-        let _ = syscall(unsafe { flock(fd, LOCK_UN) });
+        let _ = flock(&self.lock.as_fd(), FlockOperation::Unlock).ok();
     }
 }

--- a/src/sys/unix/rw_lock.rs
+++ b/src/sys/unix/rw_lock.rs
@@ -1,8 +1,8 @@
-use libc::{flock, LOCK_EX, LOCK_NB, LOCK_SH};
+use rustix::fd::BorrowedFd;
+use rustix::fs::{flock, FlockOperation};
 use std::io::{self, Error, ErrorKind};
 use std::os::unix::io::AsRawFd;
 
-use super::utils::syscall;
 use super::{RwLockReadGuard, RwLockWriteGuard};
 
 #[derive(Debug)]
@@ -18,34 +18,34 @@ impl<T: AsRawFd> RwLock<T> {
 
     #[inline]
     pub fn write(&mut self) -> io::Result<RwLockWriteGuard<'_, T>> {
-        let fd = self.inner.as_raw_fd();
-        syscall(unsafe { flock(fd, LOCK_EX) })?;
+        flock(&self.as_fd(), FlockOperation::LockExclusive)?;
         Ok(RwLockWriteGuard::new(self))
     }
 
     #[inline]
     pub fn try_write(&mut self) -> Result<RwLockWriteGuard<'_, T>, Error> {
-        let fd = self.inner.as_raw_fd();
-        syscall(unsafe { flock(fd, LOCK_EX | LOCK_NB) }).map_err(|err| match err.kind() {
+        flock(&self.as_fd(), FlockOperation::NonBlockingLockExclusive).map_err(|err| match err
+            .kind()
+        {
             ErrorKind::AlreadyExists => ErrorKind::WouldBlock.into(),
-            _ => err,
+            _ => Error::from(err),
         })?;
         Ok(RwLockWriteGuard::new(self))
     }
 
     #[inline]
     pub fn read(&self) -> io::Result<RwLockReadGuard<'_, T>> {
-        let fd = self.inner.as_raw_fd();
-        syscall(unsafe { flock(fd, LOCK_SH) })?;
+        flock(&self.as_fd(), FlockOperation::LockShared)?;
         Ok(RwLockReadGuard::new(self))
     }
 
     #[inline]
     pub fn try_read(&self) -> Result<RwLockReadGuard<'_, T>, Error> {
-        let fd = self.inner.as_raw_fd();
-        syscall(unsafe { flock(fd, LOCK_SH | LOCK_NB) }).map_err(|err| match err.kind() {
-            ErrorKind::AlreadyExists => ErrorKind::WouldBlock.into(),
-            _ => err,
+        flock(&self.as_fd(), FlockOperation::NonBlockingLockShared).map_err(|err| {
+            match err.kind() {
+                ErrorKind::AlreadyExists => ErrorKind::WouldBlock.into(),
+                _ => Error::from(err),
+            }
         })?;
         Ok(RwLockReadGuard::new(self))
     }
@@ -56,5 +56,15 @@ impl<T: AsRawFd> RwLock<T> {
         T: Sized,
     {
         self.inner
+    }
+
+    #[inline]
+    pub(crate) fn as_fd(&self) -> BorrowedFd<'_> {
+        // Safety: We assume that `self.inner`'s file descriptor is valid for
+        // at least the lifetime of `self`.
+        //
+        // Once I/O safety is stablized in std, we can switch the public API to
+        // use `AsFd` instead of `AsRawFd` and eliminate this `unsafe` block.
+        unsafe { BorrowedFd::borrow_raw_fd(self.inner.as_raw_fd()) }
     }
 }

--- a/src/sys/unix/utils.rs
+++ b/src/sys/unix/utils.rs
@@ -1,9 +1,0 @@
-use std::io;
-use std::os::raw::c_int;
-
-pub(crate) fn syscall(int: c_int) -> io::Result<()> {
-    match int {
-        0 => Ok(()),
-        _ => Err(io::Error::last_os_error()),
-    }
-}

--- a/src/sys/unix/write_guard.rs
+++ b/src/sys/unix/write_guard.rs
@@ -1,8 +1,7 @@
-use libc::{flock, LOCK_UN};
+use rustix::fs::{flock, FlockOperation};
 use std::ops;
 use std::os::unix::io::AsRawFd;
 
-use super::utils::syscall;
 use super::RwLock;
 
 #[derive(Debug)]
@@ -35,7 +34,6 @@ impl<T: AsRawFd> ops::DerefMut for RwLockWriteGuard<'_, T> {
 impl<T: AsRawFd> Drop for RwLockWriteGuard<'_, T> {
     #[inline]
     fn drop(&mut self) {
-        let fd = self.lock.inner.as_raw_fd();
-        let _ = syscall(unsafe { flock(fd, LOCK_UN) });
+        let _ = flock(&self.lock.as_fd(), FlockOperation::Unlock).ok();
     }
 }

--- a/src/sys/unsupported/read_guard.rs
+++ b/src/sys/unsupported/read_guard.rs
@@ -1,8 +1,6 @@
-use libc::{flock, LOCK_UN};
 use std::ops;
 use std::os::unix::io::AsRawFd;
 
-use super::utils::syscall;
 use super::RwLock;
 
 #[derive(Debug)]

--- a/src/sys/unsupported/rw_lock.rs
+++ b/src/sys/unsupported/rw_lock.rs
@@ -1,8 +1,6 @@
-use libc::{flock, LOCK_EX, LOCK_NB, LOCK_SH};
 use std::io::{self, Error, ErrorKind};
 use std::os::unix::io::AsRawFd;
 
-use super::utils::syscall;
 use super::{RwLockReadGuard, RwLockWriteGuard};
 
 #[derive(Debug)]

--- a/src/sys/unsupported/write_guard.rs
+++ b/src/sys/unsupported/write_guard.rs
@@ -1,8 +1,6 @@
-use libc::{flock, LOCK_UN};
 use std::ops;
 use std::os::unix::io::AsRawFd;
 
-use super::utils::syscall;
 use super::RwLock;
 
 #[derive(Debug)]


### PR DESCRIPTION
Use rustix instead of calling libc directly, which factors out several
unsafe blocks and simplifies error handling.

There is still one `unsafe` block needed, to dereference raw file
descriptors passed in from the user, since the crate still uses
`AsRawFd`. Once I/O safety is stablized in std, this crate can switch
to using `AsFd`, which will eliminate the last `unsafe` block.

This splits out just the API-compatible parts of #14. It does not include
the changes to use the `AsFd` trait in the public API, so it's not an
API-breaking change.