### PR TITLE
Update rustix to version 0.34.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ features = [
 ]
 
 [target.'cfg(unix)'.dependencies]
-rustix = "0.33.0"
+rustix = "0.34.0"
 
 [dev-dependencies]
 tempfile = "3.0.8"

--- a/src/sys/unix/rw_lock.rs
+++ b/src/sys/unix/rw_lock.rs
@@ -65,6 +65,6 @@ impl<T: AsRawFd> RwLock<T> {
         //
         // Once I/O safety is stablized in std, we can switch the public API to
         // use `AsFd` instead of `AsRawFd` and eliminate this `unsafe` block.
-        unsafe { BorrowedFd::borrow_raw_fd(self.inner.as_raw_fd()) }
+        unsafe { BorrowedFd::borrow_raw(self.inner.as_raw_fd()) }
     }
 }


### PR DESCRIPTION
`BorrowFd::borrow_raw_fd` was renamed to `BorrowFd::borrow_raw` to match the
[API in nightly].

[API in nightly]: https://doc.rust-lang.org/nightly/std/os/unix/io/struct.BorrowedFd.html#method.borrow_raw