### PR TITLE
Update to windows-sys 0.36.0.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2018"
 cfg-if = "1.0.0"
 
 [target.'cfg(windows)'.dependencies.windows-sys]
-version = "0.30.0"
+version = "0.36.0"
 features = [
     "Win32_Foundation",
     "Win32_Storage_FileSystem",

--- a/src/sys/windows/read_guard.rs
+++ b/src/sys/windows/read_guard.rs
@@ -1,3 +1,4 @@
+use windows_sys::Win32::Foundation::HANDLE;
 use windows_sys::Win32::Storage::FileSystem::UnlockFile;
 
 use std::ops;
@@ -23,7 +24,7 @@ impl<T: AsRawHandle> ops::Deref for RwLockReadGuard<'_, T> {
 impl<T: AsRawHandle> Drop for RwLockReadGuard<'_, T> {
     #[inline]
     fn drop(&mut self) {
-        let handle = self.lock.inner.as_raw_handle();
+        let handle = self.lock.inner.as_raw_handle() as HANDLE;
         syscall(unsafe { UnlockFile(handle, 0, 0, 1, 0) })
             .expect("Could not unlock the file descriptor");
     }

--- a/src/sys/windows/rw_lock.rs
+++ b/src/sys/windows/rw_lock.rs
@@ -1,6 +1,7 @@
 use std::io::{self, Error, ErrorKind};
 use std::os::windows::io::AsRawHandle;
 
+use windows_sys::Win32::Foundation::HANDLE;
 use windows_sys::Win32::Storage::FileSystem::{
     LockFileEx, LOCKFILE_EXCLUSIVE_LOCK, LOCKFILE_FAIL_IMMEDIATELY,
 };
@@ -22,7 +23,7 @@ impl<T: AsRawHandle> RwLock<T> {
     #[inline]
     pub fn read(&self) -> io::Result<RwLockReadGuard<'_, T>> {
         // See: https://stackoverflow.com/a/9186532, https://docs.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-lockfileex
-        let handle = self.inner.as_raw_handle();
+        let handle = self.inner.as_raw_handle() as HANDLE;
         let overlapped = Overlapped::zero();
         let flags = 0;
         syscall(unsafe { LockFileEx(handle, flags, 0, 1, 0, overlapped.raw()) })?;
@@ -31,7 +32,7 @@ impl<T: AsRawHandle> RwLock<T> {
 
     #[inline]
     pub fn try_read(&self) -> io::Result<RwLockReadGuard<'_, T>> {
-        let handle = self.inner.as_raw_handle();
+        let handle = self.inner.as_raw_handle() as HANDLE;
         let overlapped = Overlapped::zero();
         let flags = LOCKFILE_FAIL_IMMEDIATELY;
 
@@ -43,7 +44,7 @@ impl<T: AsRawHandle> RwLock<T> {
     #[inline]
     pub fn write(&mut self) -> io::Result<RwLockWriteGuard<'_, T>> {
         // See: https://stackoverflow.com/a/9186532, https://docs.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-lockfileex
-        let handle = self.inner.as_raw_handle();
+        let handle = self.inner.as_raw_handle() as HANDLE;
         let overlapped = Overlapped::zero();
         let flags = LOCKFILE_EXCLUSIVE_LOCK;
         syscall(unsafe { LockFileEx(handle, flags, 0, 1, 0, overlapped.raw()) })?;
@@ -52,7 +53,7 @@ impl<T: AsRawHandle> RwLock<T> {
 
     #[inline]
     pub fn try_write(&mut self) -> io::Result<RwLockWriteGuard<'_, T>> {
-        let handle = self.inner.as_raw_handle();
+        let handle = self.inner.as_raw_handle() as HANDLE;
         let overlapped = Overlapped::zero();
         let flags = LOCKFILE_FAIL_IMMEDIATELY | LOCKFILE_EXCLUSIVE_LOCK;
 

--- a/src/sys/windows/write_guard.rs
+++ b/src/sys/windows/write_guard.rs
@@ -1,3 +1,4 @@
+use windows_sys::Win32::Foundation::HANDLE;
 use windows_sys::Win32::Storage::FileSystem::UnlockFile;
 
 use std::ops;
@@ -30,7 +31,7 @@ impl<T: AsRawHandle> ops::DerefMut for RwLockWriteGuard<'_, T> {
 impl<T: AsRawHandle> Drop for RwLockWriteGuard<'_, T> {
     #[inline]
     fn drop(&mut self) {
-        let handle = self.lock.inner.as_raw_handle();
+        let handle = self.lock.inner.as_raw_handle() as HANDLE;
         syscall(unsafe { UnlockFile(handle, 0, 0, 1, 0) })
             .expect("Could not unlock the file descriptor");
     }


### PR DESCRIPTION
This aligns fd-lock's windows-sys dependency with the version now
[used in parking_lot].

The only significant change is that windows-sys' `HANDLE` type is now
`isize` instead of `*mut c_void`, which differs from Rust's `RawHandle`
type, so it needs extra casts when passing to Windows APIs.

[used in parking_lot]: https://github.com/Amanieu/parking_lot/commit/e6129be275833410a1ae81b0319ae44683ccade1