### PR TITLE
Update to rustix 0.35.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ features = [
 ]
 
 [target.'cfg(unix)'.dependencies]
-rustix = "0.34.0"
+rustix = { version = "0.35.6", features = ["fs"] }
 
 [dev-dependencies]
 tempfile = "3.0.8"


### PR DESCRIPTION
The main change for fd-lock is that most of rustix is now behind feature
flags, so that crates like fd-lock can only enable the features they
need, like "fs". This makes `cargo build` of fd-lock from a clean tree
about 20% faster on my machine.
