### PR TITLE
Update to rustix 0.36.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ features = [
 ]
 
 [target.'cfg(unix)'.dependencies]
-rustix = { version = "0.35.6", features = ["fs"] }
+rustix = { version = "0.36.0", features = ["fs"] }
 
 [dev-dependencies]
 tempfile = "3.0.8"


### PR DESCRIPTION
This is a minor update; the main change is that it uses io-lifetimes 1.0 internally, which means that on Rust 1.64 and later it's using the `OwnedFd` etc. from std instead of its own. This is not exposed in fd-lock's public API.