### PR TITLE
Ignore errors while dropping a lock

### DIFF
--- a/src/read_guard.rs
+++ b/src/read_guard.rs
@@ -11,10 +11,6 @@ use crate::sys;
 /// [`read`]: crate::RwLock::read
 /// [`try_read`]: crate::RwLock::try_read
 /// [`RwLock`]: crate::RwLock
-///
-/// # Panics
-///
-/// Dropping this type may panic if the lock fails to unlock.
 #[must_use = "if unused the RwLock will immediately unlock"]
 #[derive(Debug)]
 pub struct RwLockReadGuard<'lock, T: sys::AsRaw> {

--- a/src/sys/windows/read_guard.rs
+++ b/src/sys/windows/read_guard.rs
@@ -25,7 +25,6 @@ impl<T: AsRawHandle> Drop for RwLockReadGuard<'_, T> {
     #[inline]
     fn drop(&mut self) {
         let handle = self.lock.inner.as_raw_handle() as HANDLE;
-        syscall(unsafe { UnlockFile(handle, 0, 0, 1, 0) })
-            .expect("Could not unlock the file descriptor");
+        let _ = syscall(unsafe { UnlockFile(handle, 0, 0, 1, 0) });
     }
 }

--- a/src/sys/windows/write_guard.rs
+++ b/src/sys/windows/write_guard.rs
@@ -32,7 +32,6 @@ impl<T: AsRawHandle> Drop for RwLockWriteGuard<'_, T> {
     #[inline]
     fn drop(&mut self) {
         let handle = self.lock.inner.as_raw_handle() as HANDLE;
-        syscall(unsafe { UnlockFile(handle, 0, 0, 1, 0) })
-            .expect("Could not unlock the file descriptor");
+        let _ = syscall(unsafe { UnlockFile(handle, 0, 0, 1, 0) });
     }
 }

--- a/src/write_guard.rs
+++ b/src/write_guard.rs
@@ -11,10 +11,6 @@ use crate::sys;
 /// [`write`]: crate::RwLock::write
 /// [`try_write`]: crate::RwLock::try_write
 /// [`RwLock`]: crate::RwLock
-///
-/// # Panics
-///
-/// Dropping this type may panic if the lock fails to unlock.
 #[must_use = "if unused the RwLock will immediately unlock"]
 #[derive(Debug)]
 pub struct RwLockWriteGuard<'lock, T: sys::AsRaw> {


### PR DESCRIPTION
Fixes https://github.com/yoshuawuyts/fd-lock/issues/34. Let me know if I should also add a function like `fn unlock(self) -> Result<Self, (self, std::io::Error)>` to the locks.