### PR TITLE
Update to rustix 0.37.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ features = [
 ]
 
 [target.'cfg(unix)'.dependencies]
-rustix = { version = "0.36.0", features = ["fs"] }
+rustix = { version = "0.37.0", features = ["fs"] }
 
 [dev-dependencies]
 tempfile = "3.0.8"


### PR DESCRIPTION
Tempfile, is-terminal, and others are updating to 0.37 now, so update fd-lock too.