### PR TITLE
Switch from actions/checkout@master to actions/checkout@v3

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,7 +20,7 @@ jobs:
         rust: [stable]
 
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v3
 
     - name: Install ${{ matrix.rust }}
       uses: actions-rs/toolchain@v1
@@ -50,7 +50,7 @@ jobs:
     name: Checking fmt and docs
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v3
     - uses: actions-rs/toolchain@v1
       with:
         toolchain: nightly


### PR DESCRIPTION
It's good to use a versioned dependency anyway, and this may also fix the failure at:

https://github.com/yoshuawuyts/fd-lock/actions/runs/5249297721