### PR TITLE
Update to rustix 0.38.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ features = [
 ]
 
 [target.'cfg(unix)'.dependencies]
-rustix = { version = "0.37.0", features = ["fs"] }
+rustix = { version = "0.38.0", features = ["fs"] }
 
 [dev-dependencies]
 tempfile = "3.0.8"


### PR DESCRIPTION
This speeds up clean builds by about 50%.