### PR TITLE
Update to Rust 2021 Edition.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ keywords = ["file", "fd", "lock", "windows", "unix"]
 categories = ["filesystem", "os", "os::macos-apis", "os::unix-apis", "os::windows-apis"]
 authors = ["Yoshua Wuyts <yoshuawuyts@gmail.com>"]
 readme = "README.md"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 cfg-if = "1.0.0"


### PR DESCRIPTION
No changes are needed, and Rust 2021 Edition is supported in Rust 1.56.0 so this doesn't affect the effective MSRV.