### PR TITLE
Support windows-sys v0.59.0

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -46,6 +46,34 @@ jobs:
         command: test
         args: --all
 
+    - name: update lockfile for windows-sys v0.52.0
+      uses: actions-rs/cargo@v1
+      if: runner.os == 'Windows'
+      with:
+        command: update
+        args: -p windows-sys --precise 0.52.0
+
+    - name: check windows-sys v0.52.0
+      uses: actions-rs/cargo@v1
+      if: runner.os == 'Windows'
+      with:
+        command: test
+        args: --all
+
+    - name: update lockfile for windows-sys v0.59.0
+      uses: actions-rs/cargo@v1
+      if: runner.os == 'Windows'
+      with:
+        command: update
+        args: -p windows-sys --precise 0.59.0
+
+    - name: check windows-sys v0.59.0
+      uses: actions-rs/cargo@v1
+      if: runner.os == 'Windows'
+      with:
+        command: test
+        args: --all
+
   check_fmt_and_docs:
     name: Checking fmt and docs
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2021"
 cfg-if = "1.0.0"
 
 [target.'cfg(windows)'.dependencies.windows-sys]
-version = "0.52.0"
+version = ">=0.52.0, <0.60.0"
 features = [
     "Win32_Foundation",
     "Win32_Storage_FileSystem",


### PR DESCRIPTION
`fd-lock` is the last crate in my lockfile that uses windows-sys v0.52.0. Relax the version constraint on `windows-sys` and add tests in CI for both versions.

I also tested this locally on a Windows box.

I would love to see this change released on Crates.io. If you'd like, I can prep `Cargo.toml` for that as well in a v4.1.0 release.

Thanks!